### PR TITLE
fixed input signal for Accelerometer

### DIFF
--- a/Assets/MiraSDK/Scripts/EventSystem/MiraController.cs
+++ b/Assets/MiraSDK/Scripts/EventSystem/MiraController.cs
@@ -510,7 +510,7 @@ public class MiraController : MonoBehaviour
     {
         get
         {
-            return _instance != null ? _userInput.Gyro : Vector3.zero;
+            return _instance != null ? _userInput.Accel : Vector3.zero;
         }
     }
 


### PR DESCRIPTION
seems to be a typo, where both MiraController.gyro and MiraController.accel come from the gyro