### PR TITLE
Resolve build warnings due to unused variables

### DIFF
--- a/Assets/MiraSDK/Scripts/BTRemote/ConnectToPreviousRemote.cs
+++ b/Assets/MiraSDK/Scripts/BTRemote/ConnectToPreviousRemote.cs
@@ -18,7 +18,7 @@ using System;
 
 public class ConnectToPreviousRemote : MonoBehaviour {
 
-	Guid lastRemoteID;
+	Guid? lastRemoteID;
 
 	bool activelySearching;
 

--- a/Assets/MiraSDK/Scripts/BTRemote/RemoteButtonInput.cs
+++ b/Assets/MiraSDK/Scripts/BTRemote/RemoteButtonInput.cs
@@ -24,9 +24,6 @@ public class RemoteButtonInput
     public delegate void RemoteButtonInputEventHandler(RemoteButtonInput touchInput, EventArgs e);
     //Button Events that will be trigger internally
     public event RemoteButtonInputEventHandler OnPressChanged;
-    public event RemoteButtonInputEventHandler OnHeldState;
-    public event RemoteButtonInputEventHandler OnPresseddState;
-    public event RemoteButtonInputEventHandler OnReleasedState;
 
     private int m_PrevFrameCount=-1;
 
@@ -38,7 +35,6 @@ public class RemoteButtonInput
     private bool _isPressed = false;
     private bool _onPressed = false;
     private bool _onReleased = false;
-    private bool _onHeld = false;
 	// private bool _lastframe = false;
 
     //Button Properties
@@ -149,7 +145,6 @@ public class RemoteButtonInput
          _isPressed = false;
          _onPressed = false;
          _onReleased = false;
-         _onHeld = false;
 	     // _lastframe = false;
          m_State = false;
          m_PrevState = false;

--- a/Assets/MiraSDK/Scripts/EventSystem/MiraInputModule.cs
+++ b/Assets/MiraSDK/Scripts/EventSystem/MiraInputModule.cs
@@ -440,7 +440,7 @@ namespace UnityEngine.EventSystems
         // walk up the tree till a common root between the last entered and the current entered is found
         // send exit events up to (but not inluding) the common root. Then send enter events up to
         // (but not including the common root).
-        protected void HandlePointerExitAndEnter(PointerEventData currentPointerData, GameObject newEnterTarget)
+        protected new void HandlePointerExitAndEnter(PointerEventData currentPointerData, GameObject newEnterTarget)
         {
             // if we have no target / pointerEnter has been deleted
             // just send exit events to anything we are tracking
@@ -595,9 +595,6 @@ namespace UnityEngine.EventSystems
         /// <param name="mouseData">Mouse data.</param>
         protected void ProcessMouseEvent(MouseState mouseData)
         {
-            var pressed = mouseData.AnyPressesThisFrame();
-            var released = mouseData.AnyReleasesThisFrame();
-
             var leftButtonData = mouseData.GetButtonState(PointerEventData.InputButton.Left).eventData;
 
             // Process the first mouse button fully

--- a/Assets/MiraSDK/Scripts/MiraEditorPreview.cs
+++ b/Assets/MiraSDK/Scripts/MiraEditorPreview.cs
@@ -36,7 +36,6 @@ namespace Mira
         private float rotationAmount = 2f;
 
         private Quaternion additionalCamRotation = Quaternion.identity;
-        private Quaternion verticalOffset = Quaternion.identity;
 
         private void Start()
         {
@@ -96,7 +95,6 @@ namespace Mira
             {
                 // Allow the script to clamp based on a desired target value.
                 var targetOrientation = Quaternion.Euler(targetDirection);
-                var targetCharacterOrientation = Quaternion.Euler(targetCharacterDirection);
 
                 // Get raw mouse input for a cleaner reading on more sensitive mice.
                 var mouseDelta = new Vector2(Input.GetAxisRaw("Mouse X"), -Input.GetAxisRaw("Mouse Y"));
@@ -119,7 +117,6 @@ namespace Mira
                 if (clampInDegrees.y < 360)
                     _mouseAbsolute.y = Mathf.Clamp(_mouseAbsolute.y, -clampInDegrees.y * 0.5f, clampInDegrees.y * 0.5f);
                 transform.rotation = additionalCamRotation;
-                verticalOffset = Quaternion.AngleAxis(-_mouseAbsolute.y, targetOrientation * Vector3.right);
                 transform.localRotation *= Quaternion.AngleAxis(-_mouseAbsolute.y, targetOrientation * Vector3.right) * targetOrientation;
 
                 var yRotation = Quaternion.AngleAxis(_mouseAbsolute.x, transform.InverseTransformDirection(Vector3.up));

--- a/Assets/MiraSDK/Scripts/MiraReticle.cs
+++ b/Assets/MiraSDK/Scripts/MiraReticle.cs
@@ -84,7 +84,6 @@ public class MiraReticle : MonoBehaviour
     public Color reticleIdleColor = Color.white;
 
     private SpriteRenderer reticleRenderer;
-    private Vector3 reticleOriginalScale;
 
     private void Awake()
     {
@@ -99,7 +98,6 @@ public class MiraReticle : MonoBehaviour
         cameraRig = MiraArController.Instance.cameraRig.transform;
 
         reticleRenderer = GetComponent<SpriteRenderer>();
-        reticleOriginalScale = this.transform.localScale;
 
         if (onlyVisibleOnHover)
             GetComponent<SpriteRenderer>().enabled = false;

--- a/Assets/MiraSDK/Scripts/MiraWikitudeManager.cs
+++ b/Assets/MiraSDK/Scripts/MiraWikitudeManager.cs
@@ -53,8 +53,6 @@ public class MiraWikitudeManager : TransformOverride
     private Vector3 positionalOffset;
 
     private RotationalTrackingManager rotationalTracking;
-    
-    private bool flag = false;
 
     #endregion PrivateVariables
 

--- a/Assets/MiraSDK/TutorialAssets/Scripts/MiraGrabExample.cs
+++ b/Assets/MiraSDK/TutorialAssets/Scripts/MiraGrabExample.cs
@@ -22,7 +22,7 @@ public class MiraGrabExample : MonoBehaviour, IPointerDownHandler
 
     private bool isGrabbing = false;
 
-    private float lastTouchPosition;
+    private float? lastTouchPosition;
 
     // these OnPointer functions are automatically called when
     // the pointer interacts with a game object that this script is attached to
@@ -64,7 +64,7 @@ public class MiraGrabExample : MonoBehaviour, IPointerDownHandler
                 // scale it down so it's not too strong
                 thisTouch *= 0.05f;
 
-                touchInfluence = lastTouchPosition - thisTouch;
+                touchInfluence = (lastTouchPosition ?? 0f) - thisTouch;
             }
             lastTouchPosition = thisTouch;
 


### PR DESCRIPTION
The warnings were largely due to variables that were created but never used, or where null checking would always return true (Guid and float are non-nullable in C#). There's a related warning due to unreachable code, but the path to correct that isn't self-evident, so I'll open a related issue.